### PR TITLE
Dawn theme - CSS setting to bottom align the product card widge

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -343,10 +343,18 @@
           --spark-product-card-select-min-height: 0; /* Set a min-height for select menu*/
         }
 
+        /* This hides the default mini cart behaviour */
         .cart-count-bubble,
         cart-drawer {
           display: none !important;
         }
+
+        /* This sets product cards to bottom align the SparkLayer product card widget */
+        .card-wrapper {
+            justify-content: space-between;
+            height: 100%;
+        }
+
       </style>
 
       <!-- End SparkLayer Sample CSS Code -->


### PR DESCRIPTION
This includes some minor CSS to bottom align the product cards - it's not perfect as long product names still knock things out, but it's an improvement

https://app.clickup.com/t/862jzvc96 

BEFORE
<img width="1624" alt="Screenshot 2023-07-20 at 11 53 45" src="https://github.com/sparklayer-io/dawn/assets/76741098/52ee64e4-3476-45b7-884f-ad639c9ea42e">


AFTER
<img width="1585" alt="Screenshot 2023-07-20 at 11 53 42" src="https://github.com/sparklayer-io/dawn/assets/76741098/89b02f06-4470-42a8-a085-20223ed3f1a0">

