### PR TITLE
Update README to reflect maintenance status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Dawn with SparkLayer
 
+**⚠️ SparkLayer no longer maintains this fork**
+
+---
+
 This repository contains [SparkLayer](https://sparklayer.io)'s fork of Shopify's [Dawn](https://github.com/Shopify/dawn) theme. This fork includes SparkLayer's widgets.
 
 See [sparklayer_fork_maintenance.md](sparklayer_fork_maintenance.md) for a short guide on keeping this fork up to date.


### PR DESCRIPTION
The "install b2b theme" feature in the dashboard has been superseded by the new guided theme setup process so there's no longer a need to maintain our of fork of Dawn